### PR TITLE
Null-check email payload when getting email body

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -304,13 +304,13 @@ class GoogleWorkspaceServer {
       const getEmailBody = (payload: any): string => {
         if (!payload) return "";
 
-        if (payload.body && payload.body.data) {
+        if (payload.body?.data) {
           return Buffer.from(payload.body.data, "base64").toString("utf-8");
         }
 
         if (payload.parts && payload.parts.length > 0) {
           for (const part of payload.parts) {
-            if (part.mimeType === "text/plain") {
+            if (part.mimeType === "text/plain" && part.body?.data) {
               return Buffer.from(part.body.data, "base64").toString("utf-8");
             }
           }
@@ -379,13 +379,13 @@ class GoogleWorkspaceServer {
       const getEmailBody = (payload: any): string => {
         if (!payload) return "";
 
-        if (payload.body && payload.body.data) {
+        if (payload.body?.data) {
           return Buffer.from(payload.body.data, "base64").toString("utf-8");
         }
 
         if (payload.parts && payload.parts.length > 0) {
           for (const part of payload.parts) {
-            if (part.mimeType === "text/plain") {
+            if (part.mimeType === "text/plain" && part.body?.data) {
               return Buffer.from(part.body.data, "base64").toString("utf-8");
             }
           }
@@ -414,7 +414,6 @@ class GoogleWorkspaceServer {
           const from = headers?.find((h) => h.name === "From")?.value || "";
           const date = headers?.find((h) => h.name === "Date")?.value || "";
           const body = getEmailBody(detail.data.payload);
-          // Use helper function to extract the email body correctly
 
           return {
             id: msg.id,


### PR DESCRIPTION
When running the server from source, I ran a query to get emails using the `tool_search_emails_post` tool and got the following error:

```
{
  "query": "is:unread",
  "maxResults": 50
}
[
  "Error fetching emails: The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received undefined"
]
```

example prompt: 

```
Lets try again - set the page size to something large (eg: 50) - how many unread emails do I have?
```

Adding debug logging to this tool showed that this was failing because we were trying to dereference an email part but it was null. 

```
[DEBUG] Processing message payload for ID: 1960f7e57721e660
[DEBUG] getEmailBody called with payload
[DEBUG] Checking payload.parts, length: 5
[DEBUG] Found text/plain part, attempting to decode
[DEBUG] Error in handleSearchEmails: TypeError [ERR_INVALID_ARG_TYPE]: The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received undefined
    at Function.from (node:buffer:324:9)
    at getEmailBody (file:///Users/zach/git/gsuite-mcp/build/index.js:357:43)
    at file:///Users/zach/git/gsuite-mcp/build/index.js:382:30
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Promise.all (index 44)
    at async GoogleWorkspaceServer.handleSearchEmails (file:///Users/zach/git/gsuite-mcp/build/index.js:371:34)
    at async file:///Users/zach/git/gsuite-mcp/build/index.js:257:28 {
  code: 'ERR_INVALID_ARG_TYPE'
}
[DEBUG] Error stack: TypeError [ERR_INVALID_ARG_TYPE]: The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received undefined
    at Function.from (node:buffer:324:9)
    at getEmailBody (file:///Users/zach/git/gsuite-mcp/build/index.js:357:43)
    at file:///Users/zach/git/gsuite-mcp/build/index.js:382:30
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Promise.all (index 44)
    at async GoogleWorkspaceServer.handleSearchEmails (file:///Users/zach/git/gsuite-mcp/build/index.js:371:34)
    at async file:///Users/zach/git/gsuite-mcp/build/index.js:257:28
```